### PR TITLE
Big change reject

### DIFF
--- a/infra/src/edu/illinois/gitsvn/infra/AnalysisConfiguration.java
+++ b/infra/src/edu/illinois/gitsvn/infra/AnalysisConfiguration.java
@@ -18,6 +18,7 @@ import edu.illinois.gitsvn.infra.filters.blacklister.CopyrightJavadocImportBlack
 import edu.illinois.gitsvn.infra.filters.blacklister.FileOperationBlacklister;
 import edu.illinois.gitsvn.infra.filters.blacklister.MergeMessageCommitBlackLister;
 import edu.illinois.gitsvn.infra.filters.blacklister.MultipleParentCommitBlacklister;
+import edu.illinois.gitsvn.infra.filters.blacklister.TooManyChangesBlacklister;
 
 /**
  * Runs a preconfigured analysis on a particular repo. Subclasses provide the
@@ -80,6 +81,7 @@ public abstract class AnalysisConfiguration {
 		pipeLineFilter.addFilter(FileOperationBlacklister.getAddDiffFilter());
 		pipeLineFilter.addFilter(FileOperationBlacklister.getDeleteDiffFilter());
 		pipeLineFilter.addFilter(FileOperationBlacklister.getRenameDiffFilter());
+		pipeLineFilter.addFilter(new TooManyChangesBlacklister());
 		pipeLineFilter.addFilter(new MergeMessageCommitBlackLister());
 		pipeLineFilter.addFilter(new MultipleParentCommitBlacklister());
 		pipeLineFilter.addFilter(new CopyrightJavadocImportBlacklister());

--- a/infra/src/edu/illinois/gitsvn/infra/filters/blacklister/TooManyChangesBlacklister.java
+++ b/infra/src/edu/illinois/gitsvn/infra/filters/blacklister/TooManyChangesBlacklister.java
@@ -1,0 +1,31 @@
+package edu.illinois.gitsvn.infra.filters.blacklister;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.errors.StopWalkException;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.gitective.core.filter.commit.CommitFilter;
+import org.gitective.core.filter.commit.DiffFileCountFilter;
+
+public class TooManyChangesBlacklister extends CommitFilter {
+
+	@Override
+	public boolean include(RevWalk walker, RevCommit cmit) throws StopWalkException, MissingObjectException,
+			IncorrectObjectTypeException, IOException {
+		DiffFileCountFilter diffFileCountFilter = new DiffFileCountFilter();
+		diffFileCountFilter.include(walker, cmit);
+		long editedFiles = diffFileCountFilter.getEdited();
+		long addedFiles = diffFileCountFilter.getAdded();
+		
+		if (editedFiles > 50)
+			return false;
+		if (addedFiles > 50)
+			return false;
+		
+		return true;
+	}
+	
+}

--- a/infra/test/edu/illinois/gitsvn/infra/filters/blacklister/TooManyChangesBlacklisterTest.java
+++ b/infra/test/edu/illinois/gitsvn/infra/filters/blacklister/TooManyChangesBlacklisterTest.java
@@ -1,0 +1,82 @@
+package edu.illinois.gitsvn.infra.filters.blacklister;
+
+import java.util.Arrays;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.gitective.tests.GitTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TooManyChangesBlacklisterTest extends GitTestCase {
+
+	private TooManyChangesBlacklister blacklister;
+	private RevWalk revWalk;
+	private String[] names;
+	private String[] contents;
+
+	@Before
+	public void before() throws Exception {
+		blacklister = new TooManyChangesBlacklister();
+		revWalk = new RevWalk(Git.open(testRepo).getRepository());
+	}
+
+	@Test
+	public void testOver50Added() throws Exception {
+		RevCommit commit = addXFiles(51);
+
+		boolean result = blacklister.include(revWalk, commit);
+		assertFalse(result);
+	}
+
+	private RevCommit addXFiles(int noOfFiles) throws Exception {
+		names = new String[noOfFiles];
+		contents = new String[noOfFiles];
+
+		for (int i = 0; i < noOfFiles; i++) {
+			names[i] = i + ".java";
+			contents[i] = i + "";
+		}
+		
+		return add(Arrays.asList(names), Arrays.asList(contents));
+	}
+
+	@Test
+	public void testOver50Edited() throws Exception {
+		int noOfFiles = 51;
+		addXFiles(noOfFiles);
+		RevCommit commit = editXFiles(noOfFiles);
+		
+		
+		boolean result = blacklister.include(revWalk, commit);
+		assertFalse(result);
+	}
+
+	private RevCommit editXFiles(int noOfFiles) throws Exception {
+		for (int i = 0; i < noOfFiles; i++) {
+			names[i] = i + ".java";
+			contents[i] = contents[i] + i;
+		}
+		
+		return add(Arrays.asList(names), Arrays.asList(contents));
+	}
+	
+	@Test
+	public void testUnder50Added() throws Exception {
+		RevCommit commit = addXFiles(49);
+		boolean result = blacklister.include(revWalk, commit);
+		assertTrue(result);
+	}
+	
+	@Test
+	public void testUnder50Edited() throws Exception {
+		addXFiles(49);
+		RevCommit commit = editXFiles(49);
+		
+		boolean result = blacklister.include(revWalk, commit);
+		assertTrue(result);
+		
+	}
+
+}


### PR DESCRIPTION
This is a pull request to remove the large commits directly from the analysis (issue #25).

So far, from what I saw in the literature, 50 changed 'entities' (whatever you choose them to be. For me they are files) is a good measure for too large for a human commit. So this filter filters out all the commits that add or edit over 50 files.

Does this sound like a good idea?
